### PR TITLE
0.11 release

### DIFF
--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:trusty
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    apt-transport-https \
+    gnupg \
+    wget
+
+RUN wget https://repos.influxdata.com/influxdb.key && \
+    gpg --import influxdb.key && \
+    rm -f influxdb.key
+
+# Note the use of `get.influxdb.com/telegraf` which differs from the
+# other TICK product Dockerfiles.
+ENV TELEGRAF_VERSION 0.11.1
+RUN wget https://s3.amazonaws.com/get.influxdb.org/telegraf/telegraf_$TELEGRAF_VERSION-1_amd64.deb.asc && \
+    wget https://s3.amazonaws.com/get.influxdb.org/telegraf/telegraf_$TELEGRAF_VERSION-1_amd64.deb && \
+    gpg --verify telegraf_$TELEGRAF_VERSION-1_amd64.deb.asc telegraf_$TELEGRAF_VERSION-1_amd64.deb && \
+    dpkg -i telegraf_$TELEGRAF_VERSION-1_amd64.deb && \
+    rm -f telegraf_$TELEGRAF_VERSION-1_amd64.deb*
+
+EXPOSE 8125 8092 8094
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["telegraf", "-config", "/etc/telegraf/telegraf.conf"]

--- a/0.11/entrypoint.sh
+++ b/0.11/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+if [ "$1" = 'telegraf' ]; then
+    set -- "$@"
+fi
+
+if [ "$( echo $@ | grep "\-config /etc/telegraf/telegraf.conf")" != "" ]; then
+    # Print the config file without the comments
+    separatorLine="-------------------------------------------------"
+    echo -e $separatorLine'\n'"Using Default Config"'\n'$separatorLine 
+    sed -e  's/^\ *#.*//' /etc/telegraf/telegraf.conf | awk '{if (NF > 0) print $0}'
+    echo $separatorLine
+fi
+
+exec "$@"


### PR DESCRIPTION
Adds `0.11` release. Note, we had to switch to `ubuntu:trusty` for the moment due to an issue with `deb-systemd-invoke`, but will switch back to `debian:jessie` with the next release.