### PR TITLE
Move -config to entrypoint.sh so we can emulate 0.13

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 8125/udp 8092/udp 8094
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["telegraf", "-config", "/etc/telegraf/telegraf.conf"]
+CMD ["telegraf"]

--- a/0.12/entrypoint.sh
+++ b/0.12/entrypoint.sh
@@ -5,12 +5,10 @@ if [ "${1:0:1}" = '-' ]; then
     set -- telegraf "$@"
 fi
 
-if [ "$( echo $@ | grep "\-config /etc/telegraf/telegraf.conf")" != "" ]; then
-    # Print the config file without the comments
-    separatorLine="-------------------------------------------------"
-    echo -e $separatorLine'\n'"Using Default Config"'\n'$separatorLine 
-    sed -e  's/^\ *#.*//' /etc/telegraf/telegraf.conf | awk '{if (NF > 0) print $0}'
-    echo $separatorLine
+# TODO remove this for 0.13
+if [ "$1" = 'telegraf' ]; then
+    shift
+    set -- telegraf -config /etc/telegraf/telegraf.conf "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This emulates what 0.13 will be doing with some simple tricks in `entrypoint.sh` (https://github.com/docker-library/official-images/pull/1583#issuecomment-213602816); if `-config` is specified on the command line separately, the last one wins (and I tested that it appropriately overrides the default with this code). :+1: