### PR TITLE
Add Telegraf nightly dockerfiles

### DIFF
--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -1,0 +1,18 @@
+FROM buildpack-deps:trusty-curl
+
+RUN gpg \
+    --keyserver hkp://ha.pool.sks-keyservers.net \
+    --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+
+RUN wget -q https://dl.influxdata.com/telegraf/nightlies/telegraf_nightly_amd64.deb.asc && \
+    wget -q https://dl.influxdata.com/telegraf/nightlies/telegraf_nightly_amd64.deb && \
+    gpg --batch --verify https://dl.influxdata.com/telegraf/nightlies/telegraf_nightly_amd64.deb.asc \
+                         https://dl.influxdata.com/telegraf/nightlies/telegraf_nightly_amd64.deb && \
+    dpkg -i telegraf_nightly_amd64.deb && \
+    rm -f telegraf_nightly_amd64.deb*
+
+EXPOSE 8125/udp 8092/udp 8094
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["telegraf"]

--- a/nightly/alpine/Dockerfile
+++ b/nightly/alpine/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:3.3
+
+RUN apk add --update ca-certificates wget gnupg tar && \
+    rm /var/cache/apk/*
+
+RUN gpg --keyserver hkp://ha.pool.sks-keyservers.net \
+    --recv-keys 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+
+RUN wget -q https://dl.influxdata.com/telegraf/nightlies/telegraf-static-nightly_linux_amd64.tar.gz && \
+    wget -q https://dl.influxdata.com/telegraf/nightlies/telegraf-static-nightly_linux_amd64.tar.gz.asc && \
+    gpg --batch --verify telegraf-static-nightly_linux_amd64.tar.gz.asc telegraf-static-nightly_linux_amd64.tar.gz && \
+    tar -xvzf telegraf-static-nightly_linux_amd64.tar.gz && \
+    mv -v telegraf*/* / && \
+    rm -rf telegraf-static-nightly_linux_amd64.tar.gz
+
+EXPOSE 8125/udp 8092/udp 8094
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/telegraf"]

--- a/nightly/alpine/Dockerfile
+++ b/nightly/alpine/Dockerfile
@@ -10,7 +10,8 @@ RUN wget -q https://dl.influxdata.com/telegraf/nightlies/telegraf-static-nightly
     wget -q https://dl.influxdata.com/telegraf/nightlies/telegraf-static-nightly_linux_amd64.tar.gz.asc && \
     gpg --batch --verify telegraf-static-nightly_linux_amd64.tar.gz.asc telegraf-static-nightly_linux_amd64.tar.gz && \
     tar -xvzf telegraf-static-nightly_linux_amd64.tar.gz && \
-    mv -v telegraf*/* / && \
+    mv -v telegraf*/* /usr/bin/ && \
+    rm -f /usr/bin/telegraf.conf && \
     rm -rf telegraf-static-nightly_linux_amd64.tar.gz
 
 EXPOSE 8125/udp 8092/udp 8094

--- a/nightly/alpine/entrypoint.sh
+++ b/nightly/alpine/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+exec "/$@"

--- a/nightly/entrypoint.sh
+++ b/nightly/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- telegraf "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Adds separate directory for Telegraf nightly builds (both Ubuntu and Alpine).